### PR TITLE
Update src/org/andengine/extension/tmx/TMXLayer.java

### DIFF
--- a/src/org/andengine/extension/tmx/TMXLayer.java
+++ b/src/org/andengine/extension/tmx/TMXLayer.java
@@ -323,7 +323,7 @@ public class TMXLayer extends SpriteBatch implements TMXConstants {
 	}
 
 	private int getTileRowFromLocalY(final float pLocalY) {
-		return this.mTMXTiledMap.getTileRows() - this.getTileColumnFromLocalX(pLocalY) - 1;
+		return this.mTMXTiledMap.getTileRows() - (int)(pLocalY / this.mTMXTiledMap.getTileHeight()) - 1;
 	}
 
 	private int getTileColumnFromLocalX(final float pLocalX) {


### PR DESCRIPTION
The old method assumed that the tiles used in the TMX map were square.
This new method allows for non-square tiles. 
