### PR TITLE
Removed Base64 references

### DIFF
--- a/src/org/andengine/extension/tmx/TMXLayer.java
+++ b/src/org/andengine/extension/tmx/TMXLayer.java
@@ -19,14 +19,14 @@ import org.andengine.opengl.vbo.VertexBufferObjectManager;
 import org.andengine.util.SAXUtils;
 import org.andengine.util.StreamUtils;
 import org.andengine.util.adt.color.Color;
-import org.andengine.util.base64.Base64;
-import org.andengine.util.base64.Base64InputStream;
 import org.andengine.util.exception.AndEngineRuntimeException;
 import org.andengine.util.exception.MethodNotSupportedException;
 import org.andengine.util.math.MathUtils;
 import org.xml.sax.Attributes;
 
 import android.opengl.GLES20;
+import android.util.Base64;
+import android.util.Base64InputStream;
 
 /**
  * (c) 2010 Nicolas Gramlich


### PR DESCRIPTION
Base64 from AndEngine AnchorCenter has been removed since Android 8  already implements it. This Commit removes the References to Old AndEngine's Base64 class and replaces it with Android's Base64 so that it can compile with Andengine AnchorCenter Branch
